### PR TITLE
Support Ecto.Enum

### DIFF
--- a/lib/ostara/properties.ex
+++ b/lib/ostara/properties.ex
@@ -34,8 +34,12 @@ defmodule Ostara.Properties do
     source.__schema__(:fields)
   end
 
-  @spec propertize_type(atom()) :: map()
+  @spec propertize_type(atom() | {:parameterized, struct(), map()}) :: map()
   defp propertize_type(:binary_id) do
+    %{"type" => "string"}
+  end
+
+  defp propertize_type({:parameterized, Ecto.Enum, _params}) do
     %{"type" => "string"}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Ostara.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/gridpoint-com/ostara"
-  @version "0.4.2"
+  @version "0.4.3"
 
   def project do
     [


### PR DESCRIPTION
Quick fix for supporting `Ecto.Enum` by matching on `{:parameterized, Ecto.Enum, _params}` and using `"string"` for the type.